### PR TITLE
Add driver 'hypriot'

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/docker/machine/drivers/digitalocean"
 	_ "github.com/docker/machine/drivers/google"
 	_ "github.com/docker/machine/drivers/hyperv"
+	_ "github.com/docker/machine/drivers/hypriot"
 	_ "github.com/docker/machine/drivers/none"
 	_ "github.com/docker/machine/drivers/openstack"
 	_ "github.com/docker/machine/drivers/rackspace"

--- a/drivers/hypriot/hypriot.go
+++ b/drivers/hypriot/hypriot.go
@@ -88,7 +88,9 @@ func (d *Driver) GetURL() (string, error) {
 }
 
 func (d *Driver) GetState() (state.State, error) {
-	return state.None, nil
+	//NOTE: this is due the fact, that Kitematic recognizes onl running machines
+	//TODO: refactor and detect real machine state
+	return state.Running, nil
 }
 
 func (d *Driver) GetProviderType() provider.ProviderType {

--- a/drivers/hypriot/hypriot.go
+++ b/drivers/hypriot/hypriot.go
@@ -1,0 +1,129 @@
+package hypriot
+
+import (
+	"fmt"
+
+	"github.com/codegangsta/cli"
+	"github.com/docker/docker/api"
+	"github.com/docker/machine/drivers"
+	"github.com/docker/machine/provider"
+	"github.com/docker/machine/state"
+)
+
+// The `hypriot` driver is used to control any Hypriot related
+// Docker Host, like a Raspberry Pi connected through ssh.
+type Driver struct {
+	URL string
+}
+
+func init() {
+	drivers.Register("hypriot", &drivers.RegisteredDriver{
+		New:            NewDriver,
+		GetCreateFlags: GetCreateFlags,
+	})
+}
+
+func GetCreateFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:  "hypriot-docker-url",
+			Usage: "URL of host when no driver is selected",
+			Value: "",
+		},
+	}
+}
+
+func NewDriver(machineName string, storePath string, caCert string, privateKey string) (drivers.Driver, error) {
+	return &Driver{}, nil
+}
+
+func (d *Driver) AuthorizePort(ports []*drivers.Port) error {
+	return nil
+}
+
+func (d *Driver) Create() error {
+	return nil
+}
+
+func (d *Driver) DeauthorizePort(ports []*drivers.Port) error {
+	return nil
+}
+
+func (d *Driver) DriverName() string {
+	return "hypriot"
+}
+
+func (d *Driver) GetIP() (string, error) {
+	return "", nil
+}
+
+func (d *Driver) GetMachineName() string {
+	return ""
+}
+
+func (d *Driver) GetSSHHostname() (string, error) {
+	return "", nil
+}
+
+func (d *Driver) GetSSHKeyPath() string {
+	return ""
+}
+
+func (d *Driver) GetSSHPort() (int, error) {
+	return 0, nil
+}
+
+func (d *Driver) GetSSHUsername() string {
+	return ""
+}
+
+func (d *Driver) GetURL() (string, error) {
+	return d.URL, nil
+}
+
+func (d *Driver) GetState() (state.State, error) {
+	return state.None, nil
+}
+
+func (d *Driver) GetProviderType() provider.ProviderType {
+	return provider.None
+}
+
+func (d *Driver) Kill() error {
+	return fmt.Errorf("hosts without a driver cannot be killed")
+}
+
+func (d *Driver) PreCreateCheck() error {
+	return nil
+}
+
+func (d *Driver) Remove() error {
+	return nil
+}
+
+func (d *Driver) Restart() error {
+	return fmt.Errorf("hosts without a driver cannot be restarted")
+}
+
+func (d *Driver) SetConfigFromFlags(flags drivers.DriverOptions) error {
+	url := flags.String("hypriot-docker-url")
+
+	if url == "" {
+		return fmt.Errorf("--hypriot-docker-url option is required when no driver is selected")
+	}
+	validatedUrl, err := api.ValidateHost(url)
+	if err != nil {
+		return err
+	}
+
+	d.URL = validatedUrl
+	return nil
+}
+
+func (d *Driver) Start() error {
+	return fmt.Errorf("hosts without a driver cannot be started")
+}
+
+func (d *Driver) Stop() error {
+	return fmt.Errorf("hosts without a driver cannot be stopped")
+}

--- a/drivers/hypriot/hypriot_test.go
+++ b/drivers/hypriot/hypriot_test.go
@@ -1,0 +1,1 @@
+package hypriot

--- a/host.go
+++ b/host.go
@@ -131,6 +131,9 @@ func (h *Host) ConfigureSwarm(discovery string, master bool, host string, addr s
 	if d.DriverName() == "none" {
 		return nil
 	}
+	if d.DriverName() == "hypriot" {
+		return nil
+	}
 
 	if addr == "" {
 		ip, err := d.GetIP()
@@ -266,6 +269,9 @@ func (h *Host) ConfigureAuth() error {
 	d := h.Driver
 
 	if d.DriverName() == "none" {
+		return nil
+	}
+	if d.DriverName() == "hypriot" {
 		return nil
 	}
 
@@ -505,6 +511,8 @@ func (h *Host) Provision() error {
 	// "local" providers use b2d; no provisioning necessary
 	switch h.Driver.DriverName() {
 	case "none", "virtualbox", "vmwarefusion", "vmwarevsphere":
+		return nil
+	case "hypriot":
 		return nil
 	}
 


### PR DESCRIPTION
This driver for Docker Machine is intented to be used together with Kitematic to
control an external Docker Host. This first implementation includes only the basic
driver functions to connect a Docker running on a Raspberry Pi.
